### PR TITLE
Fixed compatabilty issue with UNIX-based Operating Systems.

### DIFF
--- a/src/main/java/net/minecraft/launchwrapper/Launch.java
+++ b/src/main/java/net/minecraft/launchwrapper/Launch.java
@@ -31,7 +31,7 @@ public class Launch {
         if (getClass().getClassLoader() instanceof URLClassLoader) {
             Collections.addAll(urls, ((URLClassLoader) getClass().getClassLoader()).getURLs());
         } else {
-            for (String s : System.getProperty("java.class.path").split(";")) {
+            for (String s : System.getProperty("java.class.path").split(File.pathSeparator)) {
                 try {
                     urls.add(new File(s).toURI().toURL());
                 } catch (MalformedURLException e) {


### PR DESCRIPTION
This fixes an compatibility issue within the Launch class. The issue is that although URLs are separated with semicolons on Microsoft Windows, colons are used on UNIX-based system (macOS and Linux for instance). This causes such systems to not be able to launch the LaunchWrapper properly. This issue is resolved by using `File.pathSeparator` instead of `";"` within line 34.